### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-info-extractor.yaml
+++ b/.github/workflows/test-info-extractor.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-windows:
     if: "contains(github.event.head_commit.message, '(info-extract)')"


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/sec_poc_llm/security/code-scanning/2](https://github.com/CBIIT/sec_poc_llm/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only reads repository contents and does not perform any write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
